### PR TITLE
chore(cli): incorrect options passing to `shell` in integration tests…

### DIFF
--- a/packages/aws-cdk/test/integ/cli/cdk-helpers.ts
+++ b/packages/aws-cdk/test/integ/cli/cdk-helpers.ts
@@ -61,9 +61,9 @@ export class TestFixture {
 
   public async shell(command: string[], options: Omit<ShellOptions, 'cwd'|'output'> = {}): Promise<string> {
     return await shell(command, {
-      ...options,
       output: this.output,
       cwd: this.integTestDir,
+      ...options,
     });
   }
 


### PR DESCRIPTION
… (#10275)

`env` and `output` from `options` should override the default. This fails an integration test that explicitly passes `cwd`

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
